### PR TITLE
upgrading terraform 0.14.8 to 0.15.5

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=terraform
 pkg_origin=core
-pkg_version=0.14.8
+pkg_version=0.15.5
 pkg_license=('MPL-2.0')
 pkg_description="Terraform is a tool for building, changing, and combining infrastructure safely and efficiently"
 pkg_upstream_url="http://www.terraform.io/"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://releases.hashicorp.com/${pkg_name}/${pkg_version}/${pkg_name}_${pkg_version}_linux_amd64.zip"
 pkg_filename="${pkg_name}_${pkg_version}_linux_amd64.zip"
-pkg_shasum=4c4c6730374f25bd70e61b83250eb52f39e340188b0f0216f7243b90396ba8b6
+pkg_shasum=3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d
 pkg_build_deps=(core/unzip)
 pkg_deps=()
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4092
Signed-off-by: RaviDuddela <RaviShankar.Duddela@progress.com>